### PR TITLE
Fix: compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ subprojects {
 
     intellij {
         version ideaVersion //IntelliJ IDEA dependency
+        updateSinceUntilBuild false
     }
 }
 


### PR DESCRIPTION
- [x] @taery 
- [x] @2Pit 

Небольшое изменение в **build.gradle**, но важное.
Запрет на патч since-build в plugin.xml.
Если оставить как есть, то минимальная версия идеи будет 162.2228.15, но не думаю что стоит так строго ограничивать минимальную версию.
После этих изменений минимальная версия Идеи в которой будет работать плагин - та что указана в plugin.xml (162.0).
