### PR TITLE
Fixed a charset problem in Windows

### DIFF
--- a/stepik-java-api/src/main/java/org/stepik/api/Utils.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/Utils.java
@@ -2,21 +2,25 @@ package org.stepik.api;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * @author meanmail
  */
 public class Utils {
+    private static final Logger logger = LoggerFactory.getLogger(Utils.class);
     @NotNull
     public static String mapToGetString(@NotNull String name, @NotNull String[] values) {
         String encodedName = encode(name);
@@ -28,7 +32,7 @@ public class Utils {
     @NotNull
     private static String encode(@NotNull String value) {
         try {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+            return URLEncoder.encode(value, UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             return value;
         }
@@ -38,10 +42,11 @@ public class Utils {
     public static String readFile(@NotNull Path file) {
         Optional<String> content;
         try {
-            content = Files.readAllLines(file)
+            content = Files.readAllLines(file, UTF_8)
                     .stream()
                     .reduce((line, text) -> text + line);
         } catch (IOException e) {
+            logger.warn("Failed reading a file: {}\n{}", file, e);
             return null;
         }
 


### PR DESCRIPTION
**Who should approve:**
- [ ] @taery

**Solves issue(s):**
[IDEA-162](https://vyahhi.myjetbrains.com/youtrack/issue/IDEA-162)

**Description (and images):**
Была проблема с кодировками при записи/чтение файлов кэша в Windows.
Files.write по-умолчанию пишет, используя defaultCharset
Files.readAllLines читает всегда в UTF-8

Сделал везде явное указание кодировки UTF-8.

*Дополнительно:*
Проверка на устаревание кэша теперь проводится перед проверкой содержимого кэш-файла.