### PR TITLE
Project auto naming

### DIFF
--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/ProjectWizardUtils.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/ProjectWizardUtils.java
@@ -1,0 +1,21 @@
+package org.stepik.plugin.projectWizard;
+
+import java.io.File;
+
+/**
+ * @author meanmail
+ */
+public class ProjectWizardUtils {
+    public static String findNonExistingFileName(String searchDirectory, String preferredName) {
+        int idx = 0;
+
+        while (true) {
+            String fileName = (idx > 0 ? preferredName + "_" + idx : preferredName);
+            if (!(new File(searchDirectory, fileName)).exists()) {
+                return fileName;
+            }
+
+            ++idx;
+        }
+    }
+}

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/ProjectWizardUtils.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/ProjectWizardUtils.java
@@ -7,15 +7,14 @@ import java.io.File;
  */
 public class ProjectWizardUtils {
     public static String findNonExistingFileName(String searchDirectory, String preferredName) {
-        int idx = 0;
+        String fileName = preferredName;
+        int idx = 1;
 
-        while (true) {
-            String fileName = (idx > 0 ? preferredName + "_" + idx : preferredName);
-            if (!(new File(searchDirectory, fileName)).exists()) {
-                return fileName;
-            }
-
+        while (new File(searchDirectory, fileName).exists()) {
+            fileName = preferredName + "_" + idx;
             ++idx;
         }
+
+        return fileName;
     }
 }

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/idea/CourseModuleBuilder.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/idea/CourseModuleBuilder.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 class CourseModuleBuilder extends AbstractModuleBuilder {
     private static final Logger logger = Logger.getInstance(CourseModuleBuilder.class);
     private final StepikProjectGenerator generator = StepikProjectGenerator.getInstance();
+    private JavaWizardStep wizardStep;
 
     @NotNull
     @Override
@@ -107,8 +108,14 @@ class CourseModuleBuilder extends AbstractModuleBuilder {
         Project project = wizardContext.getProject() == null ?
                 DefaultProjectFactory.getInstance().getDefaultProject() :
                 wizardContext.getProject();
-        wizardSteps[0] = new JavaWizardStep(generator, project);
+
+        wizardStep = new JavaWizardStep(generator, project);
+        wizardSteps[0] = wizardStep;
 
         return wizardSteps;
+    }
+
+    JavaWizardStep getWizardStep() {
+        return wizardStep;
     }
 }

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/idea/JavaWizardStep.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/idea/JavaWizardStep.java
@@ -87,4 +87,8 @@ class JavaWizardStep extends ModuleWizardStep {
         logger.info(String.format("Leaving step the project wizard with the selected course: id = %s, name = %s",
                 id, selectedCourse.getTitle()));
     }
+
+    Course getSelectedCourse() {
+        return panel.getSelectedCourse();
+    }
 }

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/idea/StepikModuleType.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/idea/StepikModuleType.java
@@ -14,6 +14,7 @@ import icons.AllStepikIcons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes;
+import org.stepik.plugin.projectWizard.ProjectWizardUtils;
 
 import javax.swing.*;
 
@@ -88,5 +89,21 @@ public class StepikModuleType extends ModuleType<CourseModuleBuilder> {
     @Override
     public boolean isValidSdk(@NotNull final Module module, final Sdk projectSdk) {
         return isValidJavaSdk(module);
+    }
+
+    @Nullable
+    @Override
+    public ModuleWizardStep modifySettingsStep(
+            @NotNull SettingsStep settingsStep, @NotNull ModuleBuilder moduleBuilder) {
+        JTextField nameField = settingsStep.getModuleNameField();
+        if (nameField != null) {
+            CourseModuleBuilder courseModuleBuilder = (CourseModuleBuilder) moduleBuilder;
+            long id = courseModuleBuilder.getWizardStep().getSelectedCourse().getId();
+            String projectName = "course" + id;
+            String projectDir = settingsStep.getContext().getProjectFileDirectory();
+            projectName = ProjectWizardUtils.findNonExistingFileName(projectDir, projectName);
+            nameField.setText(projectName);
+        }
+        return null;
     }
 }

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/idea/StepikModuleType.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/idea/StepikModuleType.java
@@ -14,9 +14,10 @@ import icons.AllStepikIcons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes;
-import org.stepik.plugin.projectWizard.ProjectWizardUtils;
 
 import javax.swing.*;
+
+import static org.stepik.plugin.projectWizard.ProjectWizardUtils.findNonExistingFileName;
 
 public class StepikModuleType extends ModuleType<CourseModuleBuilder> {
     static final String MODULE_NAME = "Stepik";
@@ -101,7 +102,7 @@ public class StepikModuleType extends ModuleType<CourseModuleBuilder> {
             long id = courseModuleBuilder.getWizardStep().getSelectedCourse().getId();
             String projectName = "course" + id;
             String projectDir = settingsStep.getContext().getProjectFileDirectory();
-            projectName = ProjectWizardUtils.findNonExistingFileName(projectDir, projectName);
+            projectName = findNonExistingFileName(projectDir, projectName);
             nameField.setText(projectName);
         }
         return null;

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/pycharm/StepikPyProjectGenerator.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/pycharm/StepikPyProjectGenerator.java
@@ -50,6 +50,8 @@ class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettin
     private final StepikProjectGenerator generator;
     private final PyCharmWizardStep wizardStep;
     private TextFieldWithBrowseButton locationField;
+    private boolean locationSetting;
+    private boolean keepLocation;
 
     private StepikPyProjectGenerator() {
         super(true);
@@ -75,6 +77,7 @@ class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettin
     @Override
     public JPanel extendBasePanel() throws ProcessCanceledException {
         locationField = null;
+        keepLocation = false;
         wizardStep.updateStep();
         return wizardStep.getComponent();
     }
@@ -91,13 +94,19 @@ class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettin
     }
 
     private void setLocation(@NotNull String location) {
+        if (keepLocation) {
+            return;
+        }
+
         TextFieldWithBrowseButton locationField = getLocationField();
 
         if (locationField == null) {
             return;
         }
 
+        locationSetting = true;
         locationField.setText(location);
+        locationSetting = false;
     }
 
     @Nullable
@@ -116,10 +125,14 @@ class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettin
         return locationField;
     }
 
+    @Override
+    public void locationChanged(@NotNull String newLocation) {
+        keepLocation = keepLocation || !locationSetting;
+    }
 
     @Override
     public void fireStateChanged() {
-        if (getLocationField() != null) {
+        if (!keepLocation && getLocationField() != null) {
             long id = wizardStep.getSelectedCourse().getId();
             String projectName = "course" + id;
             String projectDir = new File(getLocation()).getParent();

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/pycharm/StepikPyProjectGenerator.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/pycharm/StepikPyProjectGenerator.java
@@ -38,6 +38,7 @@ import org.stepik.plugin.projectWizard.ProjectWizardUtils;
 import org.stepik.plugin.projectWizard.StepikProjectGenerator;
 
 import javax.swing.*;
+import java.awt.*;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -112,14 +113,18 @@ class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettin
     @Nullable
     private TextFieldWithBrowseButton getLocationField() {
         if (locationField == null) {
-            JPanel basePanel = (JPanel) wizardStep.getComponent().getParent();
+            Container basePanel = wizardStep.getComponent().getParent();
             if (basePanel == null) {
                 return null;
             }
-            JPanel topPanel = (JPanel) basePanel.getComponent(0);
-            LabeledComponent locationComponent = (LabeledComponent) topPanel.getComponent(0);
-
-            locationField = (TextFieldWithBrowseButton) locationComponent.getComponent();
+            try {
+                Container topPanel = (Container) basePanel.getComponent(0);
+                LabeledComponent locationComponent = (LabeledComponent) topPanel.getComponent(0);
+                locationField = (TextFieldWithBrowseButton) locationComponent.getComponent();
+            } catch (ClassCastException | ArrayIndexOutOfBoundsException e) {
+                logger.warn("Auto naming for a project don't work: ", e);
+                return null;
+            }
         }
 
         return locationField;

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/pycharm/StepikPyProjectGenerator.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/pycharm/StepikPyProjectGenerator.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 
 
 class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettings> {
-    private static final Logger logger = Logger.getInstance(StepikPyProjectGenerator.class.getName());
+    private static final Logger logger = Logger.getInstance(StepikPyProjectGenerator.class);
     private static final String MODULE_NAME = "Stepik";
     private final StepikProjectGenerator generator;
     private final PyCharmWizardStep wizardStep;

--- a/stepik-union/src/main/java/org/stepik/plugin/projectWizard/ui/ProjectSettingsPanel.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/projectWizard/ui/ProjectSettingsPanel.java
@@ -10,10 +10,12 @@ import org.stepik.plugin.projectWizard.StepikProjectGenerator;
 import org.stepik.plugin.utils.Utils;
 
 import javax.swing.*;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.HierarchyListener;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ProjectSettingsPanel implements ProjectSetting {
+public class ProjectSettingsPanel implements ProjectSetting, HierarchyListener {
     private static final Logger logger = Logger.getInstance(ProjectSettingsPanel.class);
     private final Project project;
     private final List<ProjectSettingListener> listeners = new ArrayList<>();
@@ -51,6 +53,7 @@ public class ProjectSettingsPanel implements ProjectSetting {
 
         langComboBox.setVisible(visibleLangBox);
         langLabel.setVisible(visibleLangBox);
+        mainPanel.addHierarchyListener(this);
     }
 
     @NotNull
@@ -122,5 +125,10 @@ public class ProjectSettingsPanel implements ProjectSetting {
     @NotNull
     public Course getSelectedCourse() {
         return selectedCourse;
+    }
+
+    @Override
+    public void hierarchyChanged(HierarchyEvent e) {
+        notifyListeners();
     }
 }


### PR DESCRIPTION
**Who should approve:**
- [x] @taery

**Solves issue(s):**
[IDEA-151](https://vyahhi.myjetbrains.com/youtrack/issue/IDEA-151)

**Description (and images):**
Автоматическое присвоение имени проекту.
*Шаблон:*
course\<id>[_index]
где
course - константа;
\<id> - идентификатор выбранного курса;
[_index] - индекс, добавляется только если директория course<id> уже существует (index >= 1).

В PyCharm не предусмотрен стандартный способ изменять местоположение программно, поэтому используется костыль: 
Определяется родительская (базовая) панель для extendedBasePase. На ней находится поле для настройки местоположения. Этот способ будет работать пока в PyCharm'е не решат существенно изменить UI. Такие изменения не приведут к неработоспособности плагина, а лишь отключат автонаименование.