### PR TITLE
Will show a cause if a authentication failed

### DIFF
--- a/core/src/main/java/com/jetbrains/tmp/learning/stepik/StepikConnectorLogin.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/stepik/StepikConnectorLogin.java
@@ -102,7 +102,7 @@ public class StepikConnectorLogin {
                 logger.info("Refresh a token is successfully");
                 return true;
             } catch (StepikClientException re) {
-                logger.info("Refresh a token is failed: " + re.getMessage());
+                logger.info("Refresh a token failed: " + re.getMessage());
             }
         }
 
@@ -113,7 +113,7 @@ public class StepikConnectorLogin {
                 logger.info("The Authentication with a password is successfully");
                 return true;
             } catch (StepikClientException e) {
-                logger.info("The Authentication with a password is failed: " + e.getMessage());
+                logger.info("The Authentication with a password failed: " + e.getMessage());
             }
         }
 
@@ -176,7 +176,7 @@ public class StepikConnectorLogin {
             logger.info("The test authentication is successfully");
             testUser = getCurrentUser();
         } catch (StepikClientException e) {
-            logger.info("The test authentication is failed");
+            logger.info("The test authentication failed");
             throw e;
         } finally {
             stepikApiClient.setTokenInfo(currentTokenInfo);
@@ -193,7 +193,7 @@ public class StepikConnectorLogin {
                     .id(1)
                     .execute().getUser();
         } catch (StepikClientException e) {
-            logger.warn("Get current user is failed", e);
+            logger.warn("Get current user failed", e);
             return new User();
         }
     }
@@ -213,7 +213,7 @@ public class StepikConnectorLogin {
             setAuthInfo(userId, authInfo);
             logger.info("Authentication is successfully");
         } catch (StepikClientException e) {
-            logger.warn("Authentication is failed", e);
+            logger.warn("Authentication failed", e);
             throw e;
         }
     }

--- a/core/src/main/java/com/jetbrains/tmp/learning/stepik/StepikConnectorLogin.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/stepik/StepikConnectorLogin.java
@@ -171,15 +171,16 @@ public class StepikConnectorLogin {
         TokenInfo currentTokenInfo = stepikApiClient.getTokenInfo();
 
         User testUser;
-        if (authenticate(username, password)) {
+        try {
+            authenticate(username, password);
             logger.info("The test authentication is successfully");
             testUser = getCurrentUser();
-        } else {
+        } catch (StepikClientException e) {
             logger.info("The test authentication is failed");
-            testUser = new User();
+            throw e;
+        } finally {
+            stepikApiClient.setTokenInfo(currentTokenInfo);
         }
-
-        stepikApiClient.setTokenInfo(currentTokenInfo);
 
         return testUser;
     }
@@ -197,7 +198,7 @@ public class StepikConnectorLogin {
         }
     }
 
-    public static boolean authenticate(@Nullable String username, @Nullable String password) {
+    public static void authenticate(@Nullable String username, @Nullable String password) {
         try {
             stepikApiClient.oauth2()
                     .userAuthenticationPassword(CLIENT_ID, username, password)
@@ -211,10 +212,9 @@ public class StepikConnectorLogin {
             long userId = getCurrentUser().getId();
             setAuthInfo(userId, authInfo);
             logger.info("Authentication is successfully");
-            return true;
         } catch (StepikClientException e) {
             logger.warn("Authentication is failed", e);
-            return false;
+            throw e;
         }
     }
 

--- a/core/src/main/java/com/jetbrains/tmp/learning/ui/LoginPanel.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/ui/LoginPanel.java
@@ -15,9 +15,13 @@ import java.awt.event.MouseEvent;
 
 public class LoginPanel {
 
+    @SuppressWarnings("unused")
     private JPanel contentPanel;
+    @SuppressWarnings("unused")
     private JPasswordField passwordField;
+    @SuppressWarnings("unused")
     private JTextField loginField;
+    @SuppressWarnings("unused")
     private JBLabel signUpLabel;
 
     public LoginPanel(final LoginDialog dialog) {
@@ -51,10 +55,6 @@ public class LoginPanel {
 
     public JPanel getContentPanel() {
         return contentPanel;
-    }
-
-    public JTextField getLoginField() {
-        return loginField;
     }
 
     public String getPassword() {

--- a/core/src/main/java/com/jetbrains/tmp/learning/ui/LoginPanel.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/ui/LoginPanel.java
@@ -14,14 +14,9 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
 public class LoginPanel {
-
-    @SuppressWarnings("unused")
     private JPanel contentPanel;
-    @SuppressWarnings("unused")
     private JPasswordField passwordField;
-    @SuppressWarnings("unused")
     private JTextField loginField;
-    @SuppressWarnings("unused")
     private JBLabel signUpLabel;
 
     public LoginPanel(final LoginDialog dialog) {

--- a/core/src/main/java/org/stepik/core/utils/Utils.java
+++ b/core/src/main/java/org/stepik/core/utils/Utils.java
@@ -1,0 +1,18 @@
+package org.stepik.core.utils;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+
+/**
+ * @author meanmail
+ */
+public class Utils {
+    public static Project getCurrentProject() {
+        ProjectManager projectManger = ProjectManager.getInstance();
+        if (projectManger.getOpenProjects().length == 0) {
+            return projectManger.getDefaultProject();
+        } else {
+            return projectManger.getOpenProjects()[0];
+        }
+    }
+}

--- a/stepik-java-api/src/main/java/org/stepik/api/client/HttpTransportClient.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/client/HttpTransportClient.java
@@ -49,7 +49,7 @@ public class HttpTransportClient implements TransportClient {
     private static final String USER_AGENT = "Stepik Java API Client/" + StepikApiClient.getVersion();
 
     private static final int MAX_SIMULTANEOUS_CONNECTIONS = 100000;
-    private static final int FULL_CONNECTION_TIMEOUT_S = 10;
+    private static final int FULL_CONNECTION_TIMEOUT_S = 30;
     private static final int CONNECTION_TIMEOUT_MS = 5_000;
     private static final int SOCKET_TIMEOUT_MS = FULL_CONNECTION_TIMEOUT_S * 1000;
     private static final Map<Pair<String, Integer>, HttpTransportClient> instances = new HashMap<>();

--- a/stepik-java-api/src/main/java/org/stepik/api/client/HttpTransportClient.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/client/HttpTransportClient.java
@@ -2,11 +2,12 @@ package org.stepik.api.client;
 
 import javafx.util.Pair;
 import org.apache.http.Header;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -23,11 +24,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.stepik.api.exceptions.StepikClientException;
 
 import javax.net.ssl.SSLContext;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -46,7 +49,7 @@ public class HttpTransportClient implements TransportClient {
     private static final String USER_AGENT = "Stepik Java API Client/" + StepikApiClient.getVersion();
 
     private static final int MAX_SIMULTANEOUS_CONNECTIONS = 100000;
-    private static final int FULL_CONNECTION_TIMEOUT_S = 60;
+    private static final int FULL_CONNECTION_TIMEOUT_S = 10;
     private static final int CONNECTION_TIMEOUT_MS = 5_000;
     private static final int SOCKET_TIMEOUT_MS = FULL_CONNECTION_TIMEOUT_S * 1000;
     private static final Map<Pair<String, Integer>, HttpTransportClient> instances = new HashMap<>();
@@ -118,8 +121,7 @@ public class HttpTransportClient implements TransportClient {
 
     @NotNull
     @Override
-    public ClientResponse post(@NotNull StepikApiClient stepikApiClient, @NotNull String url, @Nullable String body)
-            throws IOException {
+    public ClientResponse post(@NotNull StepikApiClient stepikApiClient, @NotNull String url, @Nullable String body) {
         Map<String, String> headers = new HashMap<>();
         headers.put(CONTENT_TYPE_HEADER, CONTENT_TYPE);
 
@@ -128,7 +130,7 @@ public class HttpTransportClient implements TransportClient {
 
     @NotNull
     @Override
-    public ClientResponse get(@NotNull StepikApiClient stepikApiClient, @NotNull String url) throws IOException {
+    public ClientResponse get(@NotNull StepikApiClient stepikApiClient, @NotNull String url) {
         return get(stepikApiClient, url, null);
     }
 
@@ -138,14 +140,17 @@ public class HttpTransportClient implements TransportClient {
             @NotNull StepikApiClient stepikApiClient,
             @NotNull String url,
             @Nullable String body,
-            @Nullable Map<String, String> headers)
-            throws IOException {
+            @Nullable Map<String, String> headers) {
         HttpPost request = new HttpPost(url);
         if (headers != null) {
             headers.entrySet().forEach(entry -> request.setHeader(entry.getKey(), entry.getValue()));
         }
         if (body != null) {
-            request.setEntity(new StringEntity(body));
+            try {
+                request.setEntity(new StringEntity(body));
+            } catch (UnsupportedEncodingException e) {
+                throw new StepikClientException("Failed setting entity", e);
+            }
         }
         return call(stepikApiClient, request);
     }
@@ -154,7 +159,7 @@ public class HttpTransportClient implements TransportClient {
     public ClientResponse get(
             @NotNull StepikApiClient stepikApiClient,
             @NotNull String url,
-            @Nullable Map<String, String> headers) throws IOException {
+            @Nullable Map<String, String> headers) {
         HttpGet request = new HttpGet(url);
         if (headers != null) {
             headers.entrySet().forEach(entry -> request.setHeader(entry.getKey(), entry.getValue()));
@@ -165,14 +170,20 @@ public class HttpTransportClient implements TransportClient {
     @NotNull
     private ClientResponse call(
             @NotNull StepikApiClient stepikApiClient,
-            @NotNull HttpUriRequest request) throws IOException {
-        HttpResponse response = httpClient.execute(request);
+            @NotNull HttpUriRequest request) {
+        CloseableHttpResponse response;
+        try {
+            response = httpClient.execute(request);
+        } catch (IOException e) {
+            throw new StepikClientException("Failed a request", e);
+        }
         int statusCode = response.getStatusLine().getStatusCode();
 
         StringBuilder result = new StringBuilder();
-        if (statusCode != StatusCodes.SC_NO_CONTENT) {
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
             try (BufferedReader content = new BufferedReader(
-                    new InputStreamReader(response.getEntity().getContent(), ENCODING))) {
+                    new InputStreamReader(entity.getContent(), ENCODING))) {
 
                 String line;
                 while ((line = content.readLine()) != null) {
@@ -182,6 +193,8 @@ public class HttpTransportClient implements TransportClient {
                 if (result.length() > 0) {
                     result.deleteCharAt(0); // Delete first break line
                 }
+            } catch (IOException | UnsupportedOperationException e) {
+                throw new StepikClientException("Failed getting a content", e);
             }
         }
 

--- a/stepik-java-api/src/main/java/org/stepik/api/client/TransportClient.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/client/TransportClient.java
@@ -3,7 +3,6 @@ package org.stepik.api.client;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -11,23 +10,21 @@ import java.util.Map;
  */
 public interface TransportClient {
     @NotNull
-    ClientResponse post(@NotNull StepikApiClient stepikApiClient, @NotNull String url, @Nullable String body)
-            throws IOException;
+    ClientResponse post(@NotNull StepikApiClient stepikApiClient, @NotNull String url, @Nullable String body);
 
     @NotNull
-    ClientResponse get(@NotNull StepikApiClient stepikApiClient, @NotNull String url) throws IOException;
+    ClientResponse get(@NotNull StepikApiClient stepikApiClient, @NotNull String url);
 
     @NotNull
     ClientResponse post(
             @NotNull StepikApiClient stepikApiClient,
             @NotNull String url,
             @Nullable String body,
-            @Nullable Map<String, String> headers)
-            throws IOException;
+            @Nullable Map<String, String> headers);
 
     @NotNull
     ClientResponse get(
             @NotNull StepikApiClient stepikApiClient,
             @NotNull String url,
-            @Nullable Map<String, String> headers) throws IOException;
+            @Nullable Map<String, String> headers);
 }

--- a/stepik-java-api/src/main/java/org/stepik/api/exceptions/StepikUnauthorizedException.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/exceptions/StepikUnauthorizedException.java
@@ -1,0 +1,12 @@
+package org.stepik.api.exceptions;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author meanmail
+ */
+public class StepikUnauthorizedException extends StepikClientException {
+    public StepikUnauthorizedException(@Nullable String message) {
+        super(message);
+    }
+}

--- a/stepik-union/src/main/java/org/stepik/plugin/collective/ui/StepikSettingsPanel.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/collective/ui/StepikSettingsPanel.java
@@ -15,6 +15,7 @@ import com.jetbrains.tmp.learning.StepikProjectManager;
 import com.jetbrains.tmp.learning.StudyUtils;
 import com.jetbrains.tmp.learning.stepik.EduStepikNames;
 import com.jetbrains.tmp.learning.stepik.StepikConnectorLogin;
+import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.stepik.api.exceptions.StepikClientException;
@@ -33,35 +34,28 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.ItemEvent;
 
+import static com.intellij.openapi.ui.Messages.showMessageDialog;
+import static com.intellij.openapi.ui.Messages.showWarningDialog;
+
 class StepikSettingsPanel {
     private static final String DEFAULT_PASSWORD_TEXT = "************";
     private final static String AUTH_PASSWORD = "Password";
     private final static String AUTH_TOKEN = "Token";
-    private static final String TEST_CONNECTION = "Test a Connection";
+    private static final String TEST_CONNECTION = "Test connection";
     private static final String CHECK_CREDENTIALS = "Check credentials";
     private static final String WRONG_LOGIN_PASSWORD = "Wrong a login or a password";
     private static final String FAILED_CONNECTION = "Failed connection";
     private Project settingsProject;
-    @SuppressWarnings("unused")
     private JTextField emailTextField;
     private JPasswordField passwordField;
-    @SuppressWarnings("unused")
     private JPasswordField tokenField; // look at createUIComponents() to understand
-    @SuppressWarnings("unused")
     private JTextPane signupTextField;
-    @SuppressWarnings("unused")
     private JPanel pane;
-    @SuppressWarnings("unused")
     private JButton testButton;
-    @SuppressWarnings("unused")
     private ComboBox<String> authTypeComboBox;
-    @SuppressWarnings("unused")
     private JPanel cardPanel;
-    @SuppressWarnings("unused")
     private JBLabel authTypeLabel;
-    @SuppressWarnings("unused")
     private JButton magicButton;
-    @SuppressWarnings("unused")
     private JCheckBox hintCheckBox;
 
     private boolean credentialsModified;
@@ -76,8 +70,9 @@ class StepikSettingsPanel {
             }
         });
         magicButton.setText("Magic auth");
-        signupTextField.setText("<html>Do not have an account at stepik.org? <a href=\"" +
-                EduStepikNames.STEPIK_SIGN_IN_LINK + ">" + "Sign up" + "</a></html>");
+        @Language("HTML")
+        String signupText = "<html>Do not have an account at stepik.org? <a href='%s'>Sign up</a></html>";
+        signupTextField.setText(String.format(signupText, EduStepikNames.STEPIK_SIGN_IN_LINK));
         signupTextField.setBackground(pane.getBackground());
         signupTextField.setCursor(new Cursor(Cursor.HAND_CURSOR));
         authTypeLabel.setBorder(JBUI.Borders.emptyLeft(10));
@@ -97,11 +92,11 @@ class StepikSettingsPanel {
 
                 String fullName = user.getFirstName() + " " + user.getLastName();
                 String message = "Hello, " + fullName + "!\n I am glad to see you.";
-                Messages.showMessageDialog(message, TEST_CONNECTION, Messages.getInformationIcon());
+                showMessageDialog(message, TEST_CONNECTION, Messages.getInformationIcon());
             } catch (StepikUnauthorizedException e) {
-                showWarning(TEST_CONNECTION, WRONG_LOGIN_PASSWORD);
+                showWarningDialog(WRONG_LOGIN_PASSWORD, TEST_CONNECTION);
             } catch (StepikClientException e) {
-                showWarning(TEST_CONNECTION, FAILED_CONNECTION);
+                showWarningDialog(FAILED_CONNECTION, TEST_CONNECTION);
             }
         });
 
@@ -209,9 +204,9 @@ class StepikSettingsPanel {
                         }, "Connection at Stepik", true, Utils.getCurrentProject());
 
             } catch (StepikUnauthorizedException e) {
-                showWarning(CHECK_CREDENTIALS, WRONG_LOGIN_PASSWORD);
+                showWarningDialog(WRONG_LOGIN_PASSWORD, CHECK_CREDENTIALS);
             } catch (StepikClientException e) {
-                showWarning(CHECK_CREDENTIALS, FAILED_CONNECTION);
+                showWarningDialog(FAILED_CONNECTION, CHECK_CREDENTIALS);
             }
         }
 
@@ -220,10 +215,6 @@ class StepikSettingsPanel {
             manager.setShowHint(hintCheckBox.isSelected());
         }
         resetCredentialsModification();
-    }
-
-    private void showWarning(@NotNull String title, String message) {
-        Messages.showWarningDialog(message, title);
     }
 
     boolean isModified() {


### PR DESCRIPTION
**Who should approve:**
- [x] @taery

**Solves issue(s):**
[IDEA-159](https://vyahhi.myjetbrains.com/youtrack/issue/IDEA-159)

**Description (and images):**
1. Теперь пользователю сообщается одна из двух причин, из-за которой он не может залогиниться:
* Wrong a login or a password
* Connection failed

2. Пользователю показывается прогресс бар, пока идет аутентификация (в т.ч. и тестовая в настройках).
3. Уменьшен таймаут для сокета в HttpClient c 60 до 10 с (иначе пользователь решит, что всё зависло).