### PR TITLE
Support a debug level

### DIFF
--- a/buildSrc/src/main/groovy/org/stepik/gradle/plugins/jetbrains/BaseRunTask.groovy
+++ b/buildSrc/src/main/groovy/org/stepik/gradle/plugins/jetbrains/BaseRunTask.groovy
@@ -9,9 +9,6 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.annotations.NotNull
 
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
-
 /**
  * @author meanmail
  */
@@ -65,7 +62,6 @@ abstract class BaseRunTask extends JavaExec {
         configureClasspath()
         configureSystemProperties()
         configureJvmArgs()
-        configureLogProperties()
         super.exec()
     }
 
@@ -110,18 +106,6 @@ abstract class BaseRunTask extends JavaExec {
 
     private void configureJvmArgs() {
         jvmArgs = Utils.getProductJvmArgs(this, jvmArgs, idePath)
-    }
-
-    private void configureLogProperties() {
-        def logURL = this.getClass().getResource("/log.xml")
-        if (logURL == null){
-            println "there is no log.xml"
-            return
-        }
-
-        def source = new File(logURL.toURI())
-        def target = new File(workingDir, "log.xml")
-        Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
     }
 
     void setExtension(ProductPluginExtension extension) {

--- a/buildSrc/src/main/groovy/org/stepik/gradle/plugins/jetbrains/BaseRunTask.groovy
+++ b/buildSrc/src/main/groovy/org/stepik/gradle/plugins/jetbrains/BaseRunTask.groovy
@@ -9,6 +9,9 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.annotations.NotNull
 
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
 /**
  * @author meanmail
  */
@@ -62,6 +65,7 @@ abstract class BaseRunTask extends JavaExec {
         configureClasspath()
         configureSystemProperties()
         configureJvmArgs()
+        configureLogProperties()
         super.exec()
     }
 
@@ -106,6 +110,18 @@ abstract class BaseRunTask extends JavaExec {
 
     private void configureJvmArgs() {
         jvmArgs = Utils.getProductJvmArgs(this, jvmArgs, idePath)
+    }
+
+    private void configureLogProperties() {
+        def logURL = this.getClass().getResource("/log.xml")
+        if (logURL == null){
+            println "there is no log.xml"
+            return
+        }
+
+        def source = new File(logURL.toURI())
+        def target = new File(workingDir, "log.xml")
+        Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
     }
 
     void setExtension(ProductPluginExtension extension) {

--- a/buildSrc/src/main/groovy/org/stepik/gradle/plugins/jetbrains/PrepareSandboxTask.groovy
+++ b/buildSrc/src/main/groovy/org/stepik/gradle/plugins/jetbrains/PrepareSandboxTask.groovy
@@ -104,6 +104,7 @@ class PrepareSandboxTask extends DefaultTask {
             return
         }
         disableIdeUpdate()
+        configureLogProperties()
     }
 
     private static HashSet<Path> getDependenciesJars(@NotNull Project project) {
@@ -148,6 +149,19 @@ class PrepareSandboxTask extends DefaultTask {
         Utils.createOrRepairUpdateXml(optionsDir)
         Utils.createOrRepairIdeGeneralXml(optionsDir)
         Utils.createOrRepairOptionsXml(optionsDir)
+    }
+
+    private void configureLogProperties() {
+        def logURL = this.getClass().getResource("/log.xml")
+        if (logURL == null) {
+            println "there is no log.xml"
+            return
+        }
+
+        def workingDir = project.file("${extension.idePath}/bin/")
+        def source = new File(logURL.toURI())
+        def target = new File(workingDir, "log.xml")
+        Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
     }
 
     void setExtension(@NotNull ProductPluginExtension extension) {

--- a/buildSrc/src/main/resources/log.xml
+++ b/buildSrc/src/main/resources/log.xml
@@ -30,7 +30,7 @@
 
     <appender name="DIALOG" class="com.intellij.diagnostic.DialogAppender">
         <filter class="org.apache.log4j.varia.LevelRangeFilter">
-            <param name="LevelMin" value="INFO"/>
+            <param name="LevelMin" value="DEBUG"/>
         </filter>
     </appender>
 
@@ -50,6 +50,19 @@
             <param name="ConversionPattern" value="%d [%7r] %6p - %30.30c - %m \n"/>
         </layout>
     </appender>
+
+    <logger name="#org.stepik" additivity="false">
+        <level value="DEBUG"/>
+        <appender-ref ref="DIALOG"/>
+        <appender-ref ref="FILE"/>
+    </logger>
+
+    <logger name="#com.jetbrains.tmp" additivity="false">
+        <level value="DEBUG"/>
+        <appender-ref ref="DIALOG"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="CONSOLE-DEBUG"/>
+    </logger>
 
     <root>
         <priority value="INFO"/>

--- a/buildSrc/src/main/resources/log.xml
+++ b/buildSrc/src/main/resources/log.xml
@@ -61,7 +61,6 @@
         <level value="DEBUG"/>
         <appender-ref ref="DIALOG"/>
         <appender-ref ref="FILE"/>
-        <appender-ref ref="CONSOLE-DEBUG"/>
     </logger>
 
     <root>

--- a/buildSrc/src/main/resources/log.xml
+++ b/buildSrc/src/main/resources/log.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='ISO-8859-1' ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="CONSOLE-WARN" class="org.apache.log4j.ConsoleAppender">
+        <param name="target" value="System.err"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%7r] %6p - %30.30c - %m \n"/>
+        </layout>
+        <filter class="org.apache.log4j.varia.LevelRangeFilter">
+            <param name="LevelMin" value="WARN"/>
+        </filter>
+    </appender>
+
+    <appender name="CONSOLE-DEBUG" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%7r] %6p - %30.30c - %m \n"/>
+        </layout>
+        <filter class="org.apache.log4j.varia.LevelRangeFilter">
+            <param name="LevelMin" value="DEBUG"/>
+            <param name="LevelMax" value="DEBUG"/>
+        </filter>
+    </appender>
+
+    <appender name="CONSOLE-ALL" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%7r] %6p - %30.30c - %m \n"/>
+        </layout>
+    </appender>
+
+    <appender name="DIALOG" class="com.intellij.diagnostic.DialogAppender">
+        <filter class="org.apache.log4j.varia.LevelRangeFilter">
+            <param name="LevelMin" value="INFO"/>
+        </filter>
+    </appender>
+
+    <appender name="FILE" class="org.apache.log4j.RollingFileAppender">
+        <param name="MaxFileSize" value="1Mb"/>
+        <param name="MaxBackupIndex" value="12"/>
+        <param name="File" value="$LOG_DIR$/idea.log"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d [%7r] %6p - %30.30c - %m \n"/>
+        </layout>
+    </appender>
+
+    <appender name="CONTINUOUS_FILE" class="org.apache.log4j.FileAppender">
+        <param name="File" value="$LOG_DIR$/continuous.log"/>
+        <param name="append" value="false"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d [%7r] %6p - %30.30c - %m \n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <priority value="INFO"/>
+        <appender-ref ref="DIALOG"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</log4j:configuration>


### PR DESCRIPTION
- [ ]  @taery 
- [ ]  @meanmail 

[IDEA-188](https://vyahhi.myjetbrains.com/youtrack/issue/IDEA-188)
Добавлена возможность запускать Идею в песочнице с собственными настройками логгирования.
Это нужно чтобы перехватывать сообщения DEBUG уровня интересующих логгеров.

По стандарту Идея фильтрует все Дебаг сообщения из-за это, до сих пор, мы осуществляли всё логгирование на уровне Инфо и выше.

Теперь при запуске плагина в песочнице файл конфигурации перезаписывается файлом
`buildSrc/src/resources/log.xml`.

Различия со стандартными конфигурациями https://github.com/StepicOrg/intellij-plugins/commit/f50091665c06ff6c56f21cfe58de83d6664cb043

log.xml в IDEA, CLion и PyCharm - одинаковый.

![image](https://cloud.githubusercontent.com/assets/11159462/23141911/22b52efe-f7ca-11e6-8a1b-758aca1b2a54.png)