### PR TITLE
New a status logic for study items. Lazy creating project

### DIFF
--- a/core/src/main/java/com/jetbrains/tmp/learning/StepikProjectManager.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/StepikProjectManager.java
@@ -44,7 +44,6 @@ import org.stepik.api.objects.steps.Sample;
 import org.stepik.api.objects.steps.Step;
 import org.stepik.api.objects.steps.VideoUrl;
 import org.stepik.api.objects.users.User;
-import org.stepik.core.utils.ProjectFilesUtils;
 import org.stepik.plugin.projectWizard.idea.SandboxModuleBuilder;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -59,6 +58,7 @@ import java.io.OutputStreamWriter;
 import java.util.UUID;
 
 import static com.jetbrains.tmp.learning.SupportedLanguages.INVALID;
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 @State(name = "StepikStudySettings", storages = @Storage("stepik_study_project.xml"))
@@ -242,6 +242,7 @@ public class StepikProjectManager implements PersistentStateComponent<Element>, 
                 }, "Refreshing Course", true, project);
         ApplicationManager.getApplication().invokeLater(() -> {
             repairProjectFiles(root);
+            VirtualFileManager.getInstance().syncRefresh();
 
             VirtualFile projectDir = project != null ? project.getBaseDir() : null;
             if (projectDir != null && projectDir.findChild(EduNames.SANDBOX_DIR) == null) {
@@ -262,7 +263,7 @@ public class StepikProjectManager implements PersistentStateComponent<Element>, 
     private void repairProjectFiles(@NotNull StudyNode<?, ?> node) {
         if (project != null) {
             if (node instanceof StepNode) {
-                ProjectFilesUtils.getOrCreateSrcDirectory(project, (StepNode) node);
+                getOrCreateSrcDirectory(project, (StepNode) node, false);
             }
             node.getChildren().forEach(this::repairProjectFiles);
         }

--- a/core/src/main/java/com/jetbrains/tmp/learning/StepikProjectManager.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/StepikProjectManager.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.jetbrains.tmp.learning.core.EduNames;
 import com.jetbrains.tmp.learning.courseFormat.CourseNode;
 import com.jetbrains.tmp.learning.courseFormat.LessonNode;
@@ -44,7 +45,6 @@ import org.stepik.api.objects.steps.Sample;
 import org.stepik.api.objects.steps.Step;
 import org.stepik.api.objects.steps.VideoUrl;
 import org.stepik.api.objects.users.User;
-import org.stepik.core.utils.ProjectFilesUtils;
 import org.stepik.plugin.projectWizard.idea.SandboxModuleBuilder;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -58,6 +58,7 @@ import java.io.IOException;
 import java.util.UUID;
 
 import static com.jetbrains.tmp.learning.SupportedLanguages.INVALID;
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 
 @State(name = "StepikStudySettings", storages = @Storage("stepik_study_project.xml"))
 public class StepikProjectManager implements PersistentStateComponent<Element>, DumbAware {
@@ -240,6 +241,7 @@ public class StepikProjectManager implements PersistentStateComponent<Element>, 
                 }, "Refreshing Course", true, project);
         ApplicationManager.getApplication().invokeLater(() -> {
             repairProjectFiles(root);
+            VirtualFileManager.getInstance().syncRefresh();
 
             VirtualFile projectDir = project != null ? project.getBaseDir() : null;
             if (projectDir != null && projectDir.findChild(EduNames.SANDBOX_DIR) == null) {
@@ -260,7 +262,7 @@ public class StepikProjectManager implements PersistentStateComponent<Element>, 
     private void repairProjectFiles(@NotNull StudyNode<?, ?> node) {
         if (project != null) {
             if (node instanceof StepNode) {
-                ProjectFilesUtils.getOrCreateSrcDirectory(project, (StepNode) node);
+                getOrCreateSrcDirectory(project, (StepNode) node, false);
             }
             node.getChildren().forEach(this::repairProjectFiles);
         }

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/CourseNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/CourseNode.java
@@ -52,7 +52,8 @@ public class CourseNode extends Node<Course, SectionNode, Section, LessonNode> {
         return sections.getSections();
     }
 
-    public void init(@Nullable StudyNode parent, boolean isRestarted, @Nullable ProgressIndicator indicator) {
+    @Override
+    public void init(@Nullable StudyNode parent, @Nullable ProgressIndicator indicator) {
         if (indicator != null) {
             indicator.setText("Refresh " + getName());
             indicator.setText2("Update sections");
@@ -60,7 +61,7 @@ public class CourseNode extends Node<Course, SectionNode, Section, LessonNode> {
 
         authors = null;
 
-        super.init(parent, isRestarted, indicator);
+        super.init(parent, indicator);
     }
 
     @Override

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/LessonNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/LessonNode.java
@@ -54,7 +54,7 @@ public class LessonNode extends Node<CompoundUnitLesson, StepNode, Step, StepNod
     }
 
     @Override
-    public void init(@Nullable StudyNode parent, boolean isRestarted, @Nullable ProgressIndicator indicator) {
+    public void init(@Nullable StudyNode parent, @Nullable ProgressIndicator indicator) {
         if (indicator != null) {
             indicator.setText("Refresh a lesson: " + getName());
             indicator.setText2("Update steps");
@@ -62,7 +62,7 @@ public class LessonNode extends Node<CompoundUnitLesson, StepNode, Step, StepNod
 
         courseId = 0;
 
-        super.init(parent, isRestarted, indicator);
+        super.init(parent, indicator);
     }
 
     @Override

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/LessonNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/LessonNode.java
@@ -45,8 +45,6 @@ public class LessonNode extends Node<CompoundUnitLesson, StepNode, Step, StepNod
                         .get()
                         .id(stepsIds)
                         .execute();
-
-
             }
         } catch (StepikClientException logged) {
             logger.warn("A lesson initialization don't is fully", logged);

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/Node.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/Node.java
@@ -40,7 +40,7 @@ public abstract class Node<
 
     Node(@NotNull D data, @Nullable ProgressIndicator indicator) {
         setData(data);
-        init(null, true, indicator);
+        init(null, indicator);
     }
 
     @Nullable
@@ -193,13 +193,7 @@ public abstract class Node<
     protected abstract List<DC> getChildDataList();
 
     @Override
-    public void init(
-            @Nullable StudyNode parent,
-            boolean isRestarted,
-            @Nullable ProgressIndicator indicator) {
-        if (isRestarted) {
-            status = StudyStatus.UNCHECKED;
-        }
+    public void init(@Nullable StudyNode parent, @Nullable ProgressIndicator indicator) {
         Map<Long, C> mapNodes = getMapNodes();
         List<C> needInit = getChildren();
         setChildrenDeletedFlag();
@@ -219,7 +213,7 @@ public abstract class Node<
                 }
                 item.setData(data);
                 item.setWasDeleted(wasDeleted);
-                item.init(this, isRestarted, indicator);
+                item.init(this, indicator);
                 if (item.canBeLeaf() || !item.isLeaf()) {
                     getChildren().add(item);
                 }
@@ -230,7 +224,7 @@ public abstract class Node<
         setParent(parent);
 
         for (StudyNode child : needInit) {
-            child.init(this, isRestarted, indicator);
+            child.init(this, indicator);
         }
     }
 

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/SectionNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/SectionNode.java
@@ -35,13 +35,14 @@ public class SectionNode extends Node<Section, LessonNode, CompoundUnitLesson, S
         super(data, indicator);
     }
 
-    public void init(@Nullable final StudyNode parent, boolean isRestarted, @Nullable ProgressIndicator indicator) {
+    @Override
+    public void init(@Nullable final StudyNode parent, @Nullable ProgressIndicator indicator) {
         if (indicator != null) {
             indicator.setText("Refresh a section: " + getName());
             indicator.setText2("Update lessons");
         }
 
-        super.init(parent, isRestarted, indicator);
+        super.init(parent, indicator);
     }
 
     @Override

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StepNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StepNode.java
@@ -10,6 +10,7 @@ import com.jetbrains.tmp.learning.courseFormat.stepHelpers.SortingStepNodeHelper
 import com.jetbrains.tmp.learning.courseFormat.stepHelpers.StringStepNodeHelper;
 import com.jetbrains.tmp.learning.courseFormat.stepHelpers.VideoStepNodeHelper;
 import com.jetbrains.tmp.learning.stepik.StepikConnectorLogin;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.stepik.api.client.StepikApiClient;
@@ -36,6 +37,8 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
     private List<SupportedLanguages> supportedLanguages;
     private SupportedLanguages currentLang;
     private long courseId;
+    @XStreamOmitField
+    private int assignment;
 
     public StepNode() {}
 
@@ -313,5 +316,25 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
     @NotNull
     public MatchingStepNodeHelper asMatchingStep() {
         return new MatchingStepNodeHelper(this);
+    }
+
+    public long getAssignment() {
+        if (assignment == 0) {
+            StudyNode parent = getParent();
+            if (parent != null && parent instanceof LessonNode) {
+                LessonNode lesson = (LessonNode) parent;
+                CompoundUnitLesson data = lesson.getData();
+                if (data != null) {
+                    List<Long> steps = data.getLesson().getSteps();
+                    steps.sort(Long::compareTo);
+                    int index;
+                    if ((index = steps.indexOf(getId())) != -1) {
+                        List<Integer> assignments = data.getUnit().getAssignments();
+                        assignment = assignments.get(index);
+                    }
+                }
+            }
+        }
+        return assignment;
     }
 }

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StepNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StepNode.java
@@ -43,7 +43,8 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
         super(data, indicator);
     }
 
-    public void init(@Nullable StudyNode parent, boolean isRestarted, @Nullable ProgressIndicator indicator) {
+    @Override
+    public void init(@Nullable StudyNode parent, @Nullable ProgressIndicator indicator) {
         if (indicator != null) {
             indicator.setText("Refresh a step: " + getName());
             indicator.setText2("");
@@ -52,7 +53,7 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
         supportedLanguages = null;
         courseId = 0;
 
-        super.init(parent, isRestarted, indicator);
+        super.init(parent, indicator);
     }
 
     @Override

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StepNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StepNode.java
@@ -38,7 +38,7 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
     private SupportedLanguages currentLang;
     private long courseId;
     @XStreamOmitField
-    private int assignment;
+    private Long assignment;
 
     public StepNode() {}
 
@@ -318,8 +318,8 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
         return new MatchingStepNodeHelper(this);
     }
 
-    public long getAssignment() {
-        if (assignment == 0) {
+    public Long getAssignment() {
+        if (assignment == null) {
             StudyNode parent = getParent();
             if (parent != null && parent instanceof LessonNode) {
                 LessonNode lesson = (LessonNode) parent;
@@ -329,8 +329,10 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
                     steps.sort(Long::compareTo);
                     int index;
                     if ((index = steps.indexOf(getId())) != -1) {
-                        List<Integer> assignments = data.getUnit().getAssignments();
-                        assignment = assignments.get(index);
+                        List<Long> assignments = data.getUnit().getAssignments();
+                        if (index < assignments.size()) {
+                            assignment = assignments.get(index);
+                        }
                     }
                 }
             }

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StepNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StepNode.java
@@ -33,7 +33,6 @@ import static com.jetbrains.tmp.learning.stepik.StepikConnectorLogin.authAndGetS
 
 public class StepNode extends Node<Step, StepNode, Step, StepNode> {
     private static final Logger logger = Logger.getInstance(StepNode.class);
-    private StudyStatus status;
     private List<SupportedLanguages> supportedLanguages;
     private SupportedLanguages currentLang;
     private long courseId;
@@ -52,10 +51,6 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
 
         supportedLanguages = null;
         courseId = 0;
-
-        if (isRestarted) {
-            status = StudyStatus.UNCHECKED;
-        }
 
         super.init(parent, isRestarted, indicator);
     }
@@ -162,19 +157,6 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
         } catch (StepikClientException ignored) {
         }
         return 0;
-    }
-
-    @Override
-    @NotNull
-    public StudyStatus getStatus() {
-        if (status == null) {
-            status = StudyStatus.UNCHECKED;
-        }
-        return status;
-    }
-
-    public void setStatus(@Nullable StudyStatus status) {
-        this.status = status;
     }
 
     @NotNull
@@ -286,20 +268,24 @@ public class StepNode extends Node<Step, StepNode, Step, StepNode> {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
 
         StepNode stepNode = (StepNode) o;
 
-        if (status != stepNode.status) return false;
+        if (courseId != stepNode.courseId) return false;
         //noinspection SimplifiableIfStatement
-        if (currentLang != stepNode.currentLang) return false;
-        return super.equals(o);
+        if (supportedLanguages != null ?
+                !supportedLanguages.equals(stepNode.supportedLanguages) :
+                stepNode.supportedLanguages != null) return false;
+        return currentLang == stepNode.currentLang;
     }
 
     @Override
     public int hashCode() {
-        int result = status != null ? status.hashCode() : 0;
+        int result = super.hashCode();
+        result = 31 * result + (supportedLanguages != null ? supportedLanguages.hashCode() : 0);
         result = 31 * result + (currentLang != null ? currentLang.hashCode() : 0);
-        result = 31 * result + super.hashCode();
+        result = 31 * result + (int) (courseId ^ (courseId >>> 32));
         return result;
     }
 

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StudyNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StudyNode.java
@@ -54,13 +54,10 @@ public interface StudyNode<D extends StudyObject, C extends StudyNode> {
 
     void setData(@Nullable D data);
 
-    void init(
-            @Nullable final StudyNode parent,
-            boolean isRestarted,
-            @Nullable ProgressIndicator indicator);
+    void init(@Nullable final StudyNode parent, @Nullable ProgressIndicator indicator);
 
     default void init(@Nullable ProgressIndicator indicator) {
-        init(null, false, indicator);
+        init(null, indicator);
     }
 
     boolean canBeLeaf();

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StudyNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StudyNode.java
@@ -18,8 +18,6 @@ public interface StudyNode<D extends StudyObject, C extends StudyNode> {
 
     void setStatus(@Nullable StudyStatus status);
 
-    void updateParentStatus();
-
     @NotNull
     String getDirectory();
 
@@ -72,4 +70,10 @@ public interface StudyNode<D extends StudyObject, C extends StudyNode> {
     boolean getWasDeleted();
 
     void setWasDeleted(boolean wasDeleted);
+
+    boolean isUnknownStatus();
+
+    void setRawStatus(@Nullable StudyStatus status);
+
+    void passed();
 }

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StudyNode.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/StudyNode.java
@@ -16,6 +16,10 @@ public interface StudyNode<D extends StudyObject, C extends StudyNode> {
     @NotNull
     StudyStatus getStatus();
 
+    void setStatus(@Nullable StudyStatus status);
+
+    void updateParentStatus();
+
     @NotNull
     String getDirectory();
 

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/stepHelpers/StepHelper.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/stepHelpers/StepHelper.java
@@ -16,9 +16,6 @@ import org.stepik.api.objects.submissions.Submissions;
 import org.stepik.api.objects.users.User;
 import org.stepik.api.queries.Order;
 
-import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.SOLVED;
-import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.UNCHECKED;
-
 /**
  * @author meanmail
  */
@@ -71,13 +68,9 @@ public class StepHelper {
             reply = submission.getReply();
             status = submission.getStatus();
             stepNode.setStatus(StudyStatus.of(status));
-            if (stepNode.getStatus() == SOLVED) {
-                stepNode.updateParentStatus();
-            }
             return true;
         }
 
-        stepNode.setStatus(UNCHECKED);
         status = "active";
         return false;
     }

--- a/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/stepHelpers/StepHelper.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/courseFormat/stepHelpers/StepHelper.java
@@ -16,6 +16,7 @@ import org.stepik.api.objects.submissions.Submissions;
 import org.stepik.api.objects.users.User;
 import org.stepik.api.queries.Order;
 
+import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.SOLVED;
 import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.UNCHECKED;
 
 /**
@@ -70,6 +71,9 @@ public class StepHelper {
             reply = submission.getReply();
             status = submission.getStatus();
             stepNode.setStatus(StudyStatus.of(status));
+            if (stepNode.getStatus() == SOLVED) {
+                stepNode.updateParentStatus();
+            }
             return true;
         }
 

--- a/core/src/main/java/com/jetbrains/tmp/learning/ui/StudyToolWindow.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/ui/StudyToolWindow.java
@@ -23,10 +23,14 @@ import com.jetbrains.tmp.learning.StudyPluginConfigurator;
 import com.jetbrains.tmp.learning.StudyUtils;
 import com.jetbrains.tmp.learning.SupportedLanguages;
 import com.jetbrains.tmp.learning.courseFormat.StepNode;
+import com.jetbrains.tmp.learning.courseFormat.StepType;
 import com.jetbrains.tmp.learning.courseFormat.StudyNode;
 import com.jetbrains.tmp.learning.courseFormat.stepHelpers.VideoStepNodeHelper;
+import com.jetbrains.tmp.learning.stepik.StepikConnectorLogin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.stepik.api.client.StepikApiClient;
+import org.stepik.api.exceptions.StepikClientException;
 import org.stepik.core.utils.ProgrammingLanguageUtils;
 
 import javax.swing.*;
@@ -44,6 +48,8 @@ import static com.jetbrains.tmp.learning.StudyUtils.getStringStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getTextStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getUnknownStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getVideoStepText;
+import static com.jetbrains.tmp.learning.courseFormat.StepType.TEXT;
+import static com.jetbrains.tmp.learning.courseFormat.StepType.VIDEO;
 import static org.stepik.core.utils.PluginUtils.PLUGIN_ID;
 
 public abstract class StudyToolWindow extends SimpleToolWindowPanel implements DataProvider, Disposable, ActionListener {
@@ -59,6 +65,7 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
     private final OnePixelSplitter splitPane;
     private final Panel rightPanel;
     private final CardLayout layout;
+    private final ActionListener qualityListener;
     private Project project;
     private StepNode stepNode;
 
@@ -70,8 +77,8 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
         languageBox = new JComboBox<>();
         languageBox.addActionListener(this);
 
+        qualityListener = e -> setText();
         videoQualityBox = new JComboBox<>();
-        videoQualityBox.addActionListener(e -> setText());
 
         layout = new CardLayout();
         rightPanel = new Panel(layout);
@@ -185,8 +192,11 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
         }
         String text;
         boolean rightPanelVisible = false;
+        StepType stepType = stepNode.getType();
+        boolean theory = stepType == VIDEO || stepType == TEXT;
+        postView(theory);
 
-        switch (stepNode.getType()) {
+        switch (stepType) {
             case UNKNOWN:
                 text = getUnknownStepText(stepNode);
                 break;
@@ -202,19 +212,19 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
                 break;
             case TEXT:
                 text = getTextStepText(stepNode);
-                stepNode.passed();
                 break;
             case VIDEO:
                 VideoStepNodeHelper videoStepNode = stepNode.asVideoStep();
                 text = getVideoStepText(videoStepNode, getVideoQuality());
+                videoQualityBox.removeActionListener(qualityListener);
                 videoQualityBox.removeAllItems();
                 videoStepNode.getQualitySet().forEach(videoQualityBox::addItem);
                 int quality = videoStepNode.getQuality();
                 videoQualityBox.setSelectedItem(quality);
+                videoQualityBox.addActionListener(qualityListener);
                 layout.show(rightPanel, "quality");
                 rightPanelVisible = videoQualityBox.getModel().getSize() != 0;
                 storeVideoQuality(quality);
-                stepNode.passed();
                 break;
             case CHOICE:
                 text = getChoiceStepText(stepNode);
@@ -236,6 +246,30 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
         rightPanel.setVisible(rightPanelVisible);
         setText(text);
         ProjectView.getInstance(project).refresh();
+    }
+
+    private void postView(boolean needPassed) {
+        StepNode finalStepNode = stepNode;
+        new Thread(() -> {
+            long assignment = finalStepNode.getAssignment();
+            long stepId = finalStepNode.getId();
+            try {
+                if (assignment != 0) {
+                    StepikApiClient stepikApiClient = StepikConnectorLogin.authAndGetStepikApiClient();
+                    stepikApiClient.views()
+                            .post()
+                            .assignment(assignment)
+                            .step(stepId)
+                            .execute();
+                }
+            } catch (StepikClientException e) {
+                logger.warn(e);
+            }
+
+            if (needPassed) {
+                finalStepNode.passed();
+            }
+        }).run();
     }
 
     private int loadVideoQuality() {

--- a/core/src/main/java/com/jetbrains/tmp/learning/ui/StudyToolWindow.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/ui/StudyToolWindow.java
@@ -44,7 +44,6 @@ import static com.jetbrains.tmp.learning.StudyUtils.getStringStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getTextStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getUnknownStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getVideoStepText;
-import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.SOLVED;
 import static org.stepik.core.utils.PluginUtils.PLUGIN_ID;
 
 public abstract class StudyToolWindow extends SimpleToolWindowPanel implements DataProvider, Disposable, ActionListener {
@@ -203,8 +202,7 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
                 break;
             case TEXT:
                 text = getTextStepText(stepNode);
-                stepNode.setStatus(SOLVED);
-                stepNode.updateParentStatus();
+                stepNode.passed();
                 break;
             case VIDEO:
                 VideoStepNodeHelper videoStepNode = stepNode.asVideoStep();
@@ -216,8 +214,7 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
                 layout.show(rightPanel, "quality");
                 rightPanelVisible = videoQualityBox.getModel().getSize() != 0;
                 storeVideoQuality(quality);
-                stepNode.setStatus(SOLVED);
-                stepNode.updateParentStatus();
+                stepNode.passed();
                 break;
             case CHOICE:
                 text = getChoiceStepText(stepNode);

--- a/core/src/main/java/com/jetbrains/tmp/learning/ui/StudyToolWindow.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/ui/StudyToolWindow.java
@@ -24,7 +24,6 @@ import com.jetbrains.tmp.learning.StudyUtils;
 import com.jetbrains.tmp.learning.SupportedLanguages;
 import com.jetbrains.tmp.learning.courseFormat.StepNode;
 import com.jetbrains.tmp.learning.courseFormat.StudyNode;
-import com.jetbrains.tmp.learning.courseFormat.StudyStatus;
 import com.jetbrains.tmp.learning.courseFormat.stepHelpers.VideoStepNodeHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,6 +44,7 @@ import static com.jetbrains.tmp.learning.StudyUtils.getStringStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getTextStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getUnknownStepText;
 import static com.jetbrains.tmp.learning.StudyUtils.getVideoStepText;
+import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.SOLVED;
 import static org.stepik.core.utils.PluginUtils.PLUGIN_ID;
 
 public abstract class StudyToolWindow extends SimpleToolWindowPanel implements DataProvider, Disposable, ActionListener {
@@ -203,7 +203,8 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
                 break;
             case TEXT:
                 text = getTextStepText(stepNode);
-                stepNode.setStatus(StudyStatus.SOLVED);
+                stepNode.setStatus(SOLVED);
+                stepNode.updateParentStatus();
                 break;
             case VIDEO:
                 VideoStepNodeHelper videoStepNode = stepNode.asVideoStep();
@@ -215,7 +216,8 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
                 layout.show(rightPanel, "quality");
                 rightPanelVisible = videoQualityBox.getModel().getSize() != 0;
                 storeVideoQuality(quality);
-                stepNode.setStatus(StudyStatus.SOLVED);
+                stepNode.setStatus(SOLVED);
+                stepNode.updateParentStatus();
                 break;
             case CHOICE:
                 text = getChoiceStepText(stepNode);

--- a/core/src/main/java/com/jetbrains/tmp/learning/ui/StudyToolWindow.java
+++ b/core/src/main/java/com/jetbrains/tmp/learning/ui/StudyToolWindow.java
@@ -251,7 +251,7 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
     private void postView(boolean needPassed) {
         StepNode finalStepNode = stepNode;
         new Thread(() -> {
-            long assignment = finalStepNode.getAssignment();
+            Long assignment = finalStepNode.getAssignment();
             long stepId = finalStepNode.getId();
             try {
                 if (assignment != 0) {
@@ -263,7 +263,7 @@ public abstract class StudyToolWindow extends SimpleToolWindowPanel implements D
                             .execute();
                 }
             } catch (StepikClientException e) {
-                logger.warn(e);
+                logger.warn("Failed post view: stepId=" + stepId + "; assignment=" + assignment, e);
             }
 
             if (needPassed) {

--- a/core/src/main/java/org/stepik/core/utils/ModuleUtils.java
+++ b/core/src/main/java/org/stepik/core/utils/ModuleUtils.java
@@ -16,17 +16,17 @@ import java.io.IOException;
 /**
  * @author meanmail
  */
-public class ModuleUtils {
+class ModuleUtils {
     private static final Logger logger = Logger.getInstance(ModuleUtils.class);
 
-    public static void createStepModule(
+    static void createStepModule(
             @NotNull Project project,
             @NotNull StepNode step,
             @NotNull ModifiableModuleModel moduleModel) {
         StudyNode lesson = step.getParent();
         if (lesson != null) {
             String moduleDir = String.join("/", project.getBasePath(), lesson.getPath());
-            StepModuleBuilder stepModuleBuilder = new StepModuleBuilder(moduleDir, step, project);
+            StepModuleBuilder stepModuleBuilder = new StepModuleBuilder(moduleDir, step);
             try {
                 stepModuleBuilder.createModule(moduleModel);
             } catch (IOException | ModuleWithNameAlreadyExists | JDOMException | ConfigurationException e) {

--- a/core/src/main/java/org/stepik/plugin/actions/SendAction.java
+++ b/core/src/main/java/org/stepik/plugin/actions/SendAction.java
@@ -96,19 +96,13 @@ public class SendAction {
             @NotNull StepNode stepNode,
             @Nullable String stepStatus,
             @NotNull String hint) {
-        StudyStatus status = StudyStatus.of(stepStatus);
-
         NotificationType notificationType;
-        if (status == StudyStatus.SOLVED) {
+        if (StudyStatus.of(stepStatus) == SOLVED) {
             notificationType = NotificationType.INFORMATION;
             hint = "Success!";
+            stepNode.passed();
         } else {
             notificationType = NotificationType.WARNING;
-        }
-
-        stepNode.setStatus(status);
-        if (status == SOLVED) {
-            stepNode.updateParentStatus();
         }
 
         String title = String.format("%s is %s", stepNode.getName(), stepStatus);

--- a/core/src/main/java/org/stepik/plugin/actions/SendAction.java
+++ b/core/src/main/java/org/stepik/plugin/actions/SendAction.java
@@ -20,6 +20,7 @@ import org.stepik.core.metrics.Metrics;
 import org.stepik.core.metrics.MetricsStatus;
 import org.stepik.core.utils.Utils;
 
+import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.SOLVED;
 import static org.stepik.core.metrics.MetricsStatus.SUCCESSFUL;
 import static org.stepik.core.metrics.MetricsStatus.TIME_OVER;
 import static org.stepik.core.metrics.MetricsStatus.USER_CANCELED;
@@ -106,6 +107,9 @@ public class SendAction {
         }
 
         stepNode.setStatus(status);
+        if (status == SOLVED) {
+            stepNode.updateParentStatus();
+        }
 
         String title = String.format("%s is %s", stepNode.getName(), stepStatus);
         ActionUtils.notify(project, title, hint, notificationType);

--- a/core/src/main/java/org/stepik/plugin/projectWizard/idea/CourseModuleBuilder.java
+++ b/core/src/main/java/org/stepik/plugin/projectWizard/idea/CourseModuleBuilder.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.jetbrains.tmp.learning.StepikProjectManager;
 import com.jetbrains.tmp.learning.StudyProjectComponent;
 import com.jetbrains.tmp.learning.courseFormat.StepNode;
@@ -25,7 +26,7 @@ import org.stepik.plugin.projectWizard.StepikProjectGenerator;
 import java.io.IOException;
 
 import static org.stepik.core.projectWizard.ProjectWizardUtils.createSubDirectories;
-import static org.stepik.core.utils.ModuleUtils.createStepModule;
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 
 public class CourseModuleBuilder extends AbstractModuleBuilder {
     private static final Logger logger = Logger.getInstance(CourseModuleBuilder.class);
@@ -64,9 +65,10 @@ public class CourseModuleBuilder extends AbstractModuleBuilder {
         }
 
         if (root instanceof StepNode) {
-            createStepModule(project, (StepNode) root, moduleModel);
+            getOrCreateSrcDirectory(project, (StepNode) root, true, moduleModel);
         } else {
-            createSubDirectories(project, root, (stepNode) -> createStepModule(project, stepNode, moduleModel));
+            createSubDirectories(project, generator.getDefaultLang(), root, moduleModel);
+            VirtualFileManager.getInstance().syncRefresh();
         }
 
         ApplicationManager.getApplication().invokeLater(

--- a/core/src/main/java/org/stepik/plugin/projectWizard/idea/StepModuleBuilder.java
+++ b/core/src/main/java/org/stepik/plugin/projectWizard/idea/StepModuleBuilder.java
@@ -1,41 +1,15 @@
 package org.stepik.plugin.projectWizard.idea;
 
 import com.intellij.ide.highlighter.ModuleFileType;
-import com.intellij.openapi.module.ModifiableModuleModel;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleWithNameAlreadyExists;
-import com.intellij.openapi.options.ConfigurationException;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.io.FileUtil;
 import com.jetbrains.tmp.learning.courseFormat.StepNode;
-import org.jdom.JDOMException;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
-
-import static org.stepik.core.projectWizard.ProjectWizardUtils.createStepDirectory;
-
 public class StepModuleBuilder extends ModuleBuilderWithSrc {
-    private final StepNode stepNode;
-    private final Project project;
-
-    public StepModuleBuilder(String moduleDir, @NotNull StepNode stepNode, @NotNull Project project) {
-        this.stepNode = stepNode;
-        this.project = project;
+    public StepModuleBuilder(String moduleDir, @NotNull StepNode stepNode) {
         String stepName = stepNode.getDirectory();
         setName(stepName);
         setModuleFilePath(FileUtil.join(moduleDir, stepName,
                 stepName + ModuleFileType.DOT_DEFAULT_EXTENSION));
-    }
-
-    @NotNull
-    @Override
-    public Module createModule(@NotNull ModifiableModuleModel moduleModel) throws InvalidDataException,
-            IOException, ModuleWithNameAlreadyExists, JDOMException, ConfigurationException {
-        Module module = super.createModule(moduleModel);
-        createStepDirectory(project, stepNode);
-
-        return module;
     }
 }

--- a/core/src/main/java/org/stepik/plugin/projectWizard/pycharm/StepikPyProjectGenerator.java
+++ b/core/src/main/java/org/stepik/plugin/projectWizard/pycharm/StepikPyProjectGenerator.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.ui.LabeledComponent;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.BooleanFunction;
 import com.jetbrains.python.newProject.PyNewProjectSettings;
 import com.jetbrains.python.newProject.PythonProjectGenerator;
@@ -35,8 +36,8 @@ import javax.swing.*;
 import java.awt.*;
 import java.io.File;
 
-import static org.stepik.core.projectWizard.ProjectWizardUtils.createStepDirectory;
 import static org.stepik.core.projectWizard.ProjectWizardUtils.createSubDirectories;
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 
 
 class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettings> {
@@ -177,8 +178,7 @@ class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettin
         createCourseFromGenerator(project);
     }
 
-    private void createCourseFromGenerator(
-            @NotNull Project project) {
+    private void createCourseFromGenerator(@NotNull Project project) {
         generator.generateProject(project);
 
         FileUtil.createDirectory(new File(project.getBasePath(), "Sandbox"));
@@ -196,9 +196,10 @@ class StepikPyProjectGenerator extends PythonProjectGenerator<PyNewProjectSettin
         }
 
         if (root instanceof StepNode) {
-            createStepDirectory(project, (StepNode) root);
+            getOrCreateSrcDirectory(project, (StepNode) root, true);
         } else {
-            createSubDirectories(project, root, (step) -> createStepDirectory(project, step));
+            createSubDirectories(project, generator.getDefaultLang(), root, null);
+            VirtualFileManager.getInstance().syncRefresh();
         }
 
         ApplicationManager.getApplication().invokeLater(

--- a/core/src/main/java/org/stepik/plugin/utils/NavigationUtils.java
+++ b/core/src/main/java/org/stepik/plugin/utils/NavigationUtils.java
@@ -18,7 +18,6 @@ import com.jetbrains.tmp.learning.courseFormat.StudyNode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.stepik.core.metrics.Metrics;
-import org.stepik.core.utils.ProjectFilesUtils;
 
 import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -31,6 +30,7 @@ import java.util.Set;
 
 import static com.intellij.util.ui.tree.TreeUtil.getPathFromRoot;
 import static org.stepik.core.metrics.MetricsStatus.SUCCESSFUL;
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 
 /**
  * @author meanmail
@@ -49,7 +49,7 @@ public class NavigationUtils {
 
         VirtualFile mainFile;
         if (targetNode instanceof StepNode) {
-            VirtualFile srcDir = ProjectFilesUtils.getOrCreateSrcDirectory(project, (StepNode) targetNode);
+            VirtualFile srcDir = getOrCreateSrcDirectory(project, (StepNode) targetNode, true);
             if (srcDir == null) {
                 return;
             }

--- a/core/src/test/resources/com/jetbrains/tmp/learning/version4_4.xml
+++ b/core/src/test/resources/com/jetbrains/tmp/learning/version4_4.xml
@@ -75,7 +75,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>SOLVED</status>
                 <supportedLanguages id="19">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -160,7 +159,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="34">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -198,7 +196,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="41">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -236,7 +233,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="48">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -274,7 +270,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="55">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -343,7 +338,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="67">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -381,7 +375,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="74">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -450,7 +443,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="86">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -519,7 +511,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="98">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -557,7 +548,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="105">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -595,7 +585,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="112">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -680,7 +669,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="127">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -749,7 +737,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="139">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -818,7 +805,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="151">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -856,7 +842,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="158">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -894,7 +879,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="165">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -979,7 +963,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="180">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1017,7 +1000,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="187">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1086,7 +1068,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="199">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1155,7 +1136,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="211">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1193,7 +1173,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="218">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1278,7 +1257,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="233">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1316,7 +1294,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="240">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1385,7 +1362,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="252">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1423,7 +1399,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="259">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1492,7 +1467,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="271">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1577,7 +1551,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="286">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1646,7 +1619,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="298">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1684,7 +1656,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="305">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1753,7 +1724,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="317">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1822,7 +1792,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="329">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1860,7 +1829,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="336">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1898,7 +1866,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="343">
                   <string>Java 8</string>
                 </supportedLanguages>
@@ -1936,7 +1903,6 @@
                   <discussionsCount>0</discussionsCount>
                 </data>
                 <wasDeleted>false</wasDeleted>
-                <status>UNCHECKED</status>
                 <supportedLanguages id="350">
                   <string>Java 8</string>
                 </supportedLanguages>

--- a/stepik-java-api/src/main/java/org/stepik/api/actions/StepikProgressesAction.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/actions/StepikProgressesAction.java
@@ -2,6 +2,7 @@ package org.stepik.api.actions;
 
 import org.jetbrains.annotations.NotNull;
 import org.stepik.api.client.StepikApiClient;
+import org.stepik.api.queries.progresses.StepikProgressesGetQuery;
 
 /**
  * @author meanmail
@@ -9,5 +10,10 @@ import org.stepik.api.client.StepikApiClient;
 public class StepikProgressesAction extends StepikAbstractAction {
     public StepikProgressesAction(@NotNull StepikApiClient stepikApiClient) {
         super(stepikApiClient);
+    }
+
+    @NotNull
+    public StepikProgressesGetQuery get() {
+        return new StepikProgressesGetQuery(this);
     }
 }

--- a/stepik-java-api/src/main/java/org/stepik/api/actions/StepikViewsAction.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/actions/StepikViewsAction.java
@@ -2,6 +2,7 @@ package org.stepik.api.actions;
 
 import org.jetbrains.annotations.NotNull;
 import org.stepik.api.client.StepikApiClient;
+import org.stepik.api.queries.views.StepikViewsPostQuery;
 
 /**
  * @author meanmail
@@ -10,4 +11,10 @@ public class StepikViewsAction extends StepikAbstractAction {
     public StepikViewsAction(@NotNull StepikApiClient stepikApiClient) {
         super(stepikApiClient);
     }
+
+    @NotNull
+    public StepikViewsPostQuery post() {
+        return new StepikViewsPostQuery(this);
+    }
+
 }

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/StudyObject.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/StudyObject.java
@@ -30,4 +30,9 @@ public class StudyObject extends AbstractObject {
     public int getPosition() {
         return 0;
     }
+
+    @Nullable
+    public String getProgress() {
+        return null;
+    }
 }

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/lessons/CompoundUnitLesson.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/lessons/CompoundUnitLesson.java
@@ -79,4 +79,10 @@ public class CompoundUnitLesson extends StudyObject {
     public int getPosition() {
         return getUnit().getPosition();
     }
+
+    @Nullable
+    @Override
+    public String getProgress() {
+        return getLesson().getProgress();
+    }
 }

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/units/Unit.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/units/Unit.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class Unit extends AbstractObject {
     private int section;
     private int lesson;
-    private List<Integer> assignments;
+    private List<Long> assignments;
     private int position;
     private String progress;
     @SerializedName("begin_date")
@@ -131,14 +131,14 @@ public class Unit extends AbstractObject {
     }
 
     @NotNull
-    public List<Integer> getAssignments() {
+    public List<Long> getAssignments() {
         if (assignments == null) {
             assignments = new ArrayList<>();
         }
         return assignments;
     }
 
-    public void setAssignments(@Nullable List<Integer> assignments) {
+    public void setAssignments(@Nullable List<Long> assignments) {
         this.assignments = assignments;
     }
 

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/views/View.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/views/View.java
@@ -1,0 +1,27 @@
+package org.stepik.api.objects.views;
+
+import org.stepik.api.objects.AbstractObject;
+
+/**
+ * @author meanmail
+ */
+public class View extends AbstractObject {
+    private long assignment;
+    private long step;
+
+    public long getAssignment() {
+        return assignment;
+    }
+
+    public void setAssignment(long assignment) {
+        this.assignment = assignment;
+    }
+
+    public long getStep() {
+        return step;
+    }
+
+    public void setStep(long step) {
+        this.step = step;
+    }
+}

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/views/View.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/views/View.java
@@ -6,14 +6,14 @@ import org.stepik.api.objects.AbstractObject;
  * @author meanmail
  */
 public class View extends AbstractObject {
-    private long assignment;
+    private Long assignment;
     private long step;
 
-    public long getAssignment() {
+    public Long getAssignment() {
         return assignment;
     }
 
-    public void setAssignment(long assignment) {
+    public void setAssignment(Long assignment) {
         this.assignment = assignment;
     }
 

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/views/ViewPost.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/views/ViewPost.java
@@ -1,17 +1,20 @@
 package org.stepik.api.objects.views;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * @author meanmail
  */
 public class ViewPost {
-    private long assignment;
+    private Long assignment;
     private long step;
 
-    public long getAssignment() {
+    @Nullable
+    public Long getAssignment() {
         return assignment;
     }
 
-    public void setAssignment(long assignment) {
+    public void setAssignment(@Nullable Long assignment) {
         this.assignment = assignment;
     }
 

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/views/ViewPost.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/views/ViewPost.java
@@ -1,0 +1,25 @@
+package org.stepik.api.objects.views;
+
+/**
+ * @author meanmail
+ */
+public class ViewPost {
+    private long assignment;
+    private long step;
+
+    public long getAssignment() {
+        return assignment;
+    }
+
+    public void setAssignment(long assignment) {
+        this.assignment = assignment;
+    }
+
+    public long getStep() {
+        return step;
+    }
+
+    public void setStep(long step) {
+        this.step = step;
+    }
+}

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/views/Views.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/views/Views.java
@@ -1,0 +1,34 @@
+package org.stepik.api.objects.views;
+
+import org.jetbrains.annotations.NotNull;
+import org.stepik.api.objects.ObjectsContainer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author meanmail
+ */
+public class Views extends ObjectsContainer<View> {
+    private List<View> views;
+
+    @NotNull
+    public List<View> getViews() {
+        if (views == null) {
+            views = new ArrayList<>();
+        }
+        return views;
+    }
+
+    @NotNull
+    @Override
+    public List<View> getItems() {
+        return getViews();
+    }
+
+    @NotNull
+    @Override
+    public Class<View> getItemClass() {
+        return View.class;
+    }
+}

--- a/stepik-java-api/src/main/java/org/stepik/api/objects/views/ViewsPost.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/objects/views/ViewsPost.java
@@ -1,0 +1,23 @@
+package org.stepik.api.objects.views;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author meanmail
+ */
+public class ViewsPost {
+    private ViewPost view;
+
+    @NotNull
+    public ViewPost getView() {
+        if (view == null) {
+            view = new ViewPost();
+        }
+        return view;
+    }
+
+    public void setView(@Nullable ViewPost view) {
+        this.view = view;
+    }
+}

--- a/stepik-java-api/src/main/java/org/stepik/api/queries/StepikAbstractGetQuery.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/queries/StepikAbstractGetQuery.java
@@ -45,6 +45,13 @@ public abstract class StepikAbstractGetQuery<T extends StepikAbstractGetQuery, R
     }
 
     @NotNull
+    public T id(@NotNull String... values) {
+        addParam(IDS_KEY, values);
+        //noinspection unchecked
+        return (T) this;
+    }
+
+    @NotNull
     protected String getContentType() {
         return "application/json";
     }

--- a/stepik-java-api/src/main/java/org/stepik/api/queries/StepikAbstractQuery.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/queries/StepikAbstractQuery.java
@@ -54,6 +54,10 @@ abstract class StepikAbstractQuery<T> {
         params.put(key, new String[]{value});
     }
 
+    protected void addParam(@NotNull String key, @NotNull String... values) {
+        params.put(key, values);
+    }
+
     protected void addParam(@NotNull String key, boolean value) {
         params.put(key, new String[]{String.valueOf(value)});
     }

--- a/stepik-java-api/src/main/java/org/stepik/api/queries/progresses/StepikProgressesGetQuery.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/queries/progresses/StepikProgressesGetQuery.java
@@ -19,4 +19,9 @@ public class StepikProgressesGetQuery extends StepikAbstractGetQuery<StepikProgr
     protected String getUrl() {
         return Urls.PROGRESSES;
     }
+
+    @Override
+    protected boolean isCacheEnabled() {
+        return false;
+    }
 }

--- a/stepik-java-api/src/main/java/org/stepik/api/queries/progresses/StepikProgressesGetQuery.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/queries/progresses/StepikProgressesGetQuery.java
@@ -1,0 +1,22 @@
+package org.stepik.api.queries.progresses;
+
+import org.jetbrains.annotations.NotNull;
+import org.stepik.api.actions.StepikAbstractAction;
+import org.stepik.api.objects.progresses.Progresses;
+import org.stepik.api.queries.StepikAbstractGetQuery;
+import org.stepik.api.urls.Urls;
+
+/**
+ * @author meanmail
+ */
+public class StepikProgressesGetQuery extends StepikAbstractGetQuery<StepikProgressesGetQuery, Progresses> {
+    public StepikProgressesGetQuery(StepikAbstractAction stepikAction) {
+        super(stepikAction, Progresses.class);
+    }
+
+    @NotNull
+    @Override
+    protected String getUrl() {
+        return Urls.PROGRESSES;
+    }
+}

--- a/stepik-java-api/src/main/java/org/stepik/api/queries/views/StepikViewsPostQuery.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/queries/views/StepikViewsPostQuery.java
@@ -1,6 +1,7 @@
 package org.stepik.api.queries.views;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.stepik.api.actions.StepikAbstractAction;
 import org.stepik.api.objects.views.Views;
 import org.stepik.api.objects.views.ViewsPost;
@@ -24,7 +25,7 @@ public class StepikViewsPostQuery extends StepikAbstractPostQuery<Views> {
     }
 
     @NotNull
-    public StepikViewsPostQuery assignment(long assignment) {
+    public StepikViewsPostQuery assignment(@Nullable Long assignment) {
         views.getView().setAssignment(assignment);
         return this;
     }

--- a/stepik-java-api/src/main/java/org/stepik/api/queries/views/StepikViewsPostQuery.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/queries/views/StepikViewsPostQuery.java
@@ -1,0 +1,43 @@
+package org.stepik.api.queries.views;
+
+import org.jetbrains.annotations.NotNull;
+import org.stepik.api.actions.StepikAbstractAction;
+import org.stepik.api.objects.views.Views;
+import org.stepik.api.objects.views.ViewsPost;
+import org.stepik.api.queries.StepikAbstractPostQuery;
+import org.stepik.api.urls.Urls;
+
+/**
+ * @author meanmail
+ */
+public class StepikViewsPostQuery extends StepikAbstractPostQuery<Views> {
+    private final ViewsPost views = new ViewsPost();
+
+    public StepikViewsPostQuery(@NotNull StepikAbstractAction stepikAction) {
+        super(stepikAction, Views.class);
+    }
+
+    @NotNull
+    public StepikViewsPostQuery step(long id) {
+        views.getView().setStep(id);
+        return this;
+    }
+
+    @NotNull
+    public StepikViewsPostQuery assignment(long assignment) {
+        views.getView().setAssignment(assignment);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    protected String getBody() {
+        return getJsonConverter().toJson(views);
+    }
+
+    @NotNull
+    @Override
+    protected String getUrl() {
+        return Urls.VIEWS;
+    }
+}

--- a/stepik-java-api/src/main/java/org/stepik/api/urls/Urls.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/urls/Urls.java
@@ -19,4 +19,5 @@ public class Urls {
     public static final String METRICS = STEPIK_API_URL + "/metrics";
     public static final String STEPIKS = STEPIK_API_URL + "/stepics";
     public static final String USERS = STEPIK_API_URL + "/users";
+    public static final String PROGRESSES = STEPIK_API_URL + "/progresses";
 }

--- a/stepik-java-api/src/main/java/org/stepik/api/urls/Urls.java
+++ b/stepik-java-api/src/main/java/org/stepik/api/urls/Urls.java
@@ -20,4 +20,5 @@ public class Urls {
     public static final String STEPIKS = STEPIK_API_URL + "/stepics";
     public static final String USERS = STEPIK_API_URL + "/users";
     public static final String PROGRESSES = STEPIK_API_URL + "/progresses";
+    public static final String VIEWS = STEPIK_API_URL + "/views";
 }

--- a/stepik-union/src/main/java/org/stepik/plugin/actions/step/DownloadSubmission.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/actions/step/DownloadSubmission.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
+import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.SOLVED;
 import static org.stepik.core.metrics.MetricsStatus.DATA_NOT_LOADED;
 import static org.stepik.core.metrics.MetricsStatus.EMPTY_SOURCE;
 import static org.stepik.core.metrics.MetricsStatus.SUCCESSFUL;
@@ -222,7 +223,11 @@ public class DownloadSubmission extends AbstractStepAction {
 
                             if (document != null) {
                                 document.setText(finalCode);
-                                stepNode.setStatus(StudyStatus.of(submission.getStatus()));
+                                StudyStatus status = StudyStatus.of(submission.getStatus());
+                                stepNode.setStatus(status);
+                                if (status == SOLVED) {
+                                    stepNode.updateParentStatus();
+                                }
                                 FileEditorManager.getInstance(project).openFile(mainFile, true);
                                 ProjectView.getInstance(project).refresh();
                                 Metrics.downloadAction(project, stepNode, SUCCESSFUL);

--- a/stepik-union/src/main/java/org/stepik/plugin/actions/step/DownloadSubmission.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/actions/step/DownloadSubmission.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
-import static com.jetbrains.tmp.learning.courseFormat.StudyStatus.SOLVED;
 import static org.stepik.core.metrics.MetricsStatus.DATA_NOT_LOADED;
 import static org.stepik.core.metrics.MetricsStatus.EMPTY_SOURCE;
 import static org.stepik.core.metrics.MetricsStatus.SUCCESSFUL;
@@ -225,9 +224,6 @@ public class DownloadSubmission extends AbstractStepAction {
                                 document.setText(finalCode);
                                 StudyStatus status = StudyStatus.of(submission.getStatus());
                                 stepNode.setStatus(status);
-                                if (status == SOLVED) {
-                                    stepNode.updateParentStatus();
-                                }
                                 FileEditorManager.getInstance(project).openFile(mainFile, true);
                                 ProjectView.getInstance(project).refresh();
                                 Metrics.downloadAction(project, stepNode, SUCCESSFUL);

--- a/stepik-union/src/main/java/org/stepik/plugin/actions/step/DownloadSubmission.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/actions/step/DownloadSubmission.java
@@ -35,7 +35,6 @@ import org.stepik.api.objects.submissions.Submission;
 import org.stepik.api.objects.submissions.Submissions;
 import org.stepik.api.queries.Order;
 import org.stepik.core.metrics.Metrics;
-import org.stepik.core.utils.ProjectFilesUtils;
 import org.stepik.core.utils.Utils;
 
 import javax.swing.*;
@@ -52,6 +51,7 @@ import static org.stepik.core.metrics.MetricsStatus.EMPTY_SOURCE;
 import static org.stepik.core.metrics.MetricsStatus.SUCCESSFUL;
 import static org.stepik.core.metrics.MetricsStatus.TARGET_NOT_FOUND;
 import static org.stepik.core.metrics.MetricsStatus.USER_CANCELED;
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 
 /**
  * @author meanmail
@@ -200,7 +200,7 @@ public class DownloadSubmission extends AbstractStepAction {
 
         String fileName = stepNode.getCurrentLang().getMainFileName();
 
-        VirtualFile src = ProjectFilesUtils.getOrCreateSrcDirectory(project, stepNode);
+        VirtualFile src = getOrCreateSrcDirectory(project, stepNode, true);
         if (src == null) {
             Metrics.downloadAction(project, stepNode, TARGET_NOT_FOUND);
             return;

--- a/stepik-union/src/main/java/org/stepik/plugin/actions/step/InsertStepikDirectives.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/actions/step/InsertStepikDirectives.java
@@ -17,13 +17,13 @@ import com.jetbrains.tmp.learning.courseFormat.StepNode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.stepik.core.metrics.Metrics;
-import org.stepik.core.utils.ProjectFilesUtils;
 import org.stepik.plugin.utils.DirectivesUtils;
 import org.stepik.plugin.utils.ReformatUtils;
 
 import javax.swing.*;
 
 import static org.stepik.core.metrics.MetricsStatus.SUCCESSFUL;
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 import static org.stepik.plugin.utils.DirectivesUtils.insertAmbientCode;
 import static org.stepik.plugin.utils.DirectivesUtils.removeAmbientCode;
 import static org.stepik.plugin.utils.DirectivesUtils.writeInToFile;
@@ -73,7 +73,7 @@ public class InsertStepikDirectives extends AbstractStepAction {
 
         SupportedLanguages currentLang = targetStepNode.getCurrentLang();
 
-        VirtualFile src = ProjectFilesUtils.getOrCreateSrcDirectory(project, targetStepNode);
+        VirtualFile src = getOrCreateSrcDirectory(project, targetStepNode, true);
         if (src == null) {
             return;
         }

--- a/stepik-union/src/main/java/org/stepik/plugin/actions/step/StepikJavaPostAction.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/actions/step/StepikJavaPostAction.java
@@ -18,7 +18,6 @@ import org.stepik.api.objects.attempts.Attempts;
 import org.stepik.api.objects.submissions.Submission;
 import org.stepik.api.objects.submissions.Submissions;
 import org.stepik.core.metrics.Metrics;
-import org.stepik.core.utils.ProjectFilesUtils;
 import org.stepik.core.utils.Utils;
 import org.stepik.plugin.actions.ActionUtils;
 import org.stepik.plugin.actions.SendAction;
@@ -30,6 +29,7 @@ import static org.stepik.core.metrics.MetricsStatus.DATA_NOT_LOADED;
 import static org.stepik.core.metrics.MetricsStatus.FAILED_POST;
 import static org.stepik.core.metrics.MetricsStatus.SUCCESSFUL;
 import static org.stepik.core.metrics.MetricsStatus.USER_CANCELED;
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 
 public class StepikJavaPostAction extends StudyCheckAction {
     private static final Logger logger = Logger.getInstance(StepikJavaPostAction.class);
@@ -132,7 +132,7 @@ public class StepikJavaPostAction extends StudyCheckAction {
             @NotNull Project project,
             @NotNull StepNode stepNode,
             @NotNull SupportedLanguages currentLang) {
-        VirtualFile src = ProjectFilesUtils.getOrCreateSrcDirectory(project, stepNode);
+        VirtualFile src = getOrCreateSrcDirectory(project, stepNode, true);
         if (src == null) {
             return null;
         }

--- a/stepik-union/src/main/java/org/stepik/plugin/actions/step/StepikResetStepAction.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/actions/step/StepikResetStepAction.java
@@ -18,9 +18,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.stepik.core.metrics.Metrics;
 import org.stepik.core.metrics.MetricsStatus;
-import org.stepik.core.utils.ProjectFilesUtils;
 
 import javax.swing.*;
+
+import static org.stepik.core.utils.ProjectFilesUtils.getOrCreateSrcDirectory;
 
 public class StepikResetStepAction extends AbstractStepAction {
     private static final String ACTION_ID = "STEPIK.ResetStepAction";
@@ -43,7 +44,7 @@ public class StepikResetStepAction extends AbstractStepAction {
             return;
         }
 
-        VirtualFile src = ProjectFilesUtils.getOrCreateSrcDirectory(project, stepNode);
+        VirtualFile src = getOrCreateSrcDirectory(project, stepNode, true);
         if (src == null) {
             return;
         }

--- a/stepik-union/src/main/java/org/stepik/plugin/actions/step/StepikResetStepAction.java
+++ b/stepik-union/src/main/java/org/stepik/plugin/actions/step/StepikResetStepAction.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.problems.WolfTheProblemSolver;
 import com.jetbrains.tmp.learning.StudyUtils;
 import com.jetbrains.tmp.learning.courseFormat.StepNode;
-import com.jetbrains.tmp.learning.courseFormat.StudyStatus;
 import icons.AllStepikIcons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -57,7 +56,6 @@ public class StepikResetStepAction extends AbstractStepAction {
             Document document = documentManager.getDocument(mainFile);
             if (document != null) {
                 resetDocument(project, document, stepNode);
-                stepNode.setStatus(StudyStatus.UNCHECKED);
                 ProjectView.getInstance(project).refresh();
                 StudyUtils.updateToolWindows(project);
                 WolfTheProblemSolver.getInstance(project).clearProblems(mainFile);


### PR DESCRIPTION
**Who should approve:**
- [ ] @taery

**Solves issue(s):**
[IDEA-181](https://vyahhi.myjetbrains.com/youtrack/issue/IDEA-181)
**Description (and images):**
1. Файлы (Main.java и т.п.) создаются только когда происходит переход к шагу или переключение языка, а не во время создания проекта.
2. Файл создается с содержимым последнего отправленного решения, если оно есть.
3. Статусы для StudyNode теперь как в веб-версии (пройден/не пройден) и не зависят от правильности последнего решения (иконки в дереве проекта). Правильность последнего решения отображается только в Step Description.
4. Отправляются "view". Это нужно, чтобы учитывались просмотры из плагина и шаги с теорией считались пройденными при просмотре их в плагине.